### PR TITLE
Fixes

### DIFF
--- a/rosetta/services/account.go
+++ b/rosetta/services/account.go
@@ -126,7 +126,7 @@ func (a AccountAPIService) AccountBalance(ctx context.Context,
 
 		switch request.AccountIdentifier.SubAccount.Address {
 		case LockedBalanceStr:
-			lockedFunds := stateMultisig.AmountLocked(queryTipSet.Height())
+			lockedFunds := stateMultisig.AmountLocked(queryTipSet.Height() - stateMultisig.StartEpoch)
 			balanceStr = lockedFunds.String()
 		case SpendableBalanceStr:
 			available, err := a.node.MsigGetAvailableBalance(ctx, addr, queryTipSet.Key())

--- a/rosetta/services/account_test.go
+++ b/rosetta/services/account_test.go
@@ -36,7 +36,7 @@ func TestAccountAPIService_AccountBalance(t *testing.T) {
 	mockTipSet := buildMockTargetTipSet(mockHeight)
 	mockTipSetHash, _ := BuildTipSetKeyHash(mockTipSet.Key())
 	mockAddress := "t0128015"
-	mockMsigActor := buildActorMock(builtin.MultisigActorCodeID, "1000")
+	mockMsigActor := buildActorMock(builtin.MultisigActorCodeID, "100")
 	mockActorState := buildMultisigActorStateMock(mockMsigActor)
 	///
 
@@ -144,7 +144,7 @@ func TestAccountAPIService_AccountBalance(t *testing.T) {
 				},
 				Balances: []*types.Amount{
 					{
-						Value:    "0",
+						Value:    "100",
 						Currency: GetCurrencyData(),
 						Metadata: nil,
 					},

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -225,8 +225,14 @@ func processTrace(trace *filTypes.ExecutionTrace, operations *[]*types.Operation
 		return
 	}
 
-	fromPk := GetActorPubKey(&trace.Msg.From)
-	toPk := GetActorPubKey(&trace.Msg.To)
+	fromPk, err1 := GetActorPubKey(trace.Msg.From)
+	toPk, err2 := GetActorPubKey(trace.Msg.To)
+
+	if err1 != nil || err2 != nil {
+		Logger.Error("could not retrieve one or both pubkeys for addresses:",
+			trace.Msg.From.String(), trace.Msg.To.String())
+		return
+	}
 
 	opStatus := OperationStatusFailed
 	if trace.MsgRct.ExitCode.IsSuccess() {

--- a/rosetta/services/helpers.go
+++ b/rosetta/services/helpers.go
@@ -74,18 +74,13 @@ func GetMethodName(msg *filTypes.Message) (string, *types.Error) {
 		return "Constructor", nil
 	}
 
-	var (
-		actorCode cid.Cid
-		skipDB    bool
-	)
+	var actorCode cid.Cid
 
 	// Search for actor in cache
-	if !skipDB {
-		var err error
-		actorCode, err = tools.ActorsDB.GetActorCode(msg.To)
-		if err != nil {
-			return unknownStr, nil
-		}
+	var err error
+	actorCode, err = tools.ActorsDB.GetActorCode(msg.To)
+	if err != nil {
+		return unknownStr, nil
 	}
 
 	var method interface{}

--- a/rosetta/services/helpers.go
+++ b/rosetta/services/helpers.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/hex"
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/zondax/rosetta-filecoin-proxy/rosetta/tools"
 	"reflect"
@@ -121,6 +122,19 @@ func GetMethodName(msg *filTypes.Message) (string, *types.Error) {
 
 	methodName := val.Type().Field(idx).Name
 	return methodName, nil
+}
+
+func GetActorPubKey(add *address.Address) string {
+	var pubKey string
+	switch add.Protocol() {
+	case address.BLS, address.SECP256K1, address.Actor:
+		pubKey = add.String()
+	default:
+		// Search for actor's pubkey in cache
+		pubKey = tools.ActorsDB.GetActorPubKey(*add)
+	}
+
+	return pubKey
 }
 
 func GetSupportedOpList() []string {

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"time"
-
 	"github.com/filecoin-project/lotus/api"
 	filTypes "github.com/filecoin-project/lotus/chain/types"
 )
-
-const DummyHash = "0000000000000000000000000000000000000000"
 
 // NetworkAPIService implements the server.NetworkAPIServicer interface.
 type NetworkAPIService struct {
@@ -57,7 +53,7 @@ func (s *NetworkAPIService) NetworkStatus(
 	var (
 		headTipSet            *filTypes.TipSet
 		err                   error
-		useDummyHead          = false
+		useGenesisTipSet      = false
 		blockIndex, timeStamp int64
 		blockHashedTipSet     string
 	)
@@ -76,8 +72,8 @@ func (s *NetworkAPIService) NetworkStatus(
 	}
 	if !status.IsSynced() {
 		//Cannot retrieve any TipSet while node is syncing
-		//use a dummy TipSet instead
-		useDummyHead = true
+		//use Genesis TipSet instead
+		useGenesisTipSet = true
 	}
 
 	//Get head TipSet
@@ -116,14 +112,14 @@ func (s *NetworkAPIService) NetworkStatus(
 		})
 	}
 
-	if !useDummyHead {
+	if !useGenesisTipSet {
 		blockIndex = int64(headTipSet.Height())
 		timeStamp = int64(headTipSet.MinTimestamp()) * FactorSecondToMillisecond
 		blockHashedTipSet = *hashHeadTipSet
 	} else {
 		blockIndex = 0
-		timeStamp = time.Now().Unix() * FactorSecondToMillisecond
-		blockHashedTipSet = DummyHash
+		timeStamp = int64(genesisTipSet.MinTimestamp()) * FactorSecondToMillisecond
+		blockHashedTipSet = *hashGenesisTipSet
 	}
 
 	resp := &types.NetworkStatusResponse{

--- a/rosetta/tests/rosetta_test.go
+++ b/rosetta/tests/rosetta_test.go
@@ -395,7 +395,7 @@ func TestSendTransaction(t *testing.T) {
 func TestGetBalance(t *testing.T) {
 
 	rosettaClient := setupRosettaClient()
-	testAddress := "t023232"
+	testAddress := "t020406"
 
 	fmt.Println("Testing on address:", testAddress)
 

--- a/rosetta/tools/actors_database.go
+++ b/rosetta/tools/actors_database.go
@@ -13,23 +13,29 @@ var ActorsDB Database
 
 type Database interface {
 	NewImpl(*api.FullNode)
+	//Address-ActorCID Map
 	GetActorCode(address address.Address) (cid.Cid, error)
 	storeActorCode(address address.Address, actorCode cid.Cid)
+	//Address-ActorPubkey Map
+	GetActorPubKey(address address.Address) string
+	storeActorPubKey(address address.Address, pubKey string)
 }
 
 /// In-memory database ///
 type Cache struct {
-	data cmap.ConcurrentMap
-	Node *api.FullNode
+	cidMap    cmap.ConcurrentMap
+	pubKeyMap cmap.ConcurrentMap
+	Node      *api.FullNode
 }
 
 func (m *Cache) NewImpl(node *api.FullNode) {
-	m.data = cmap.New()
+	m.cidMap = cmap.New()
+	m.pubKeyMap = cmap.New()
 	m.Node = node
 }
 
 func (m *Cache) GetActorCode(address address.Address) (cid.Cid, error) {
-	code, ok := m.data.Get(address.String())
+	code, ok := m.cidMap.Get(address.String())
 	if !ok {
 		var err error
 		code, err = m.retrieveActorFromLotus(address)
@@ -43,7 +49,7 @@ func (m *Cache) GetActorCode(address address.Address) (cid.Cid, error) {
 }
 
 func (m *Cache) storeActorCode(key address.Address, value cid.Cid) {
-	m.data.Set(key.String(), value)
+	m.cidMap.Set(key.String(), value)
 }
 
 func (m *Cache) retrieveActorFromLotus(add address.Address) (cid.Cid, error) {
@@ -53,6 +59,29 @@ func (m *Cache) retrieveActorFromLotus(add address.Address) (cid.Cid, error) {
 	}
 
 	return actor.Code, nil
+}
+
+func (m *Cache) GetActorPubKey(address address.Address) string {
+	pubKey, ok := m.pubKeyMap.Get(address.String())
+	if !ok {
+		pubKey = m.retrieveActorPubKeyFromLotus(&address)
+		m.storeActorPubKey(address, pubKey.(string))
+	}
+
+	return pubKey.(string)
+}
+
+func (m *Cache) storeActorPubKey(address address.Address, pubKey string) {
+	m.pubKeyMap.Set(address.String(), pubKey)
+}
+
+func (m *Cache) retrieveActorPubKeyFromLotus(add *address.Address) string {
+	key, err := (*m.Node).StateAccountKey(context.Background(), *add, filTypes.EmptyTSK)
+	if err != nil {
+		return add.String()
+	}
+
+	return key.String()
 }
 
 /////


### PR DESCRIPTION
- Use in memory map to track Address-ID pairs for fast lookup. 
- Normalize addresses, if possible, by converting them to the "robust" equivalent before registering an operation.
- Return balance of 0FIL if actor is not queryable at requested height.
- Fix `current_block_identifier` timestamp when node is syncing.
- Minor code cleanup.
- Fix #72 