### PR TITLE
Upgrade lotus v1.26.0-rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v1.28.3
 	github.com/filecoin-project/go-jsonrpc v0.3.1
 	github.com/filecoin-project/go-state-types v0.13.0-rc.2
-	github.com/filecoin-project/lotus v1.26.0-rc2
+	github.com/filecoin-project/lotus v1.26.0-rc3
 	github.com/filecoin-project/specs-actors v0.9.15
 	github.com/filecoin-project/specs-actors/v8 v8.0.1
 	github.com/google/uuid v1.6.0
@@ -22,7 +22,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zondax/rosetta-filecoin-lib v1.2600.0-rc1
+	github.com/zondax/rosetta-filecoin-lib v1.2600.0-rc3
 	gotest.tools v2.2.0+incompatible
 )
 

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/filecoin-project/kubo-api-client v0.0.1 h1:IR1b+sm+VYxSRvbgECVv9SbhIg
 github.com/filecoin-project/kubo-api-client v0.0.1/go.mod h1:c36PPMIVOkKfHDwDG5U05gUlPRY9wNuh/BePwo0e+6Y=
 github.com/filecoin-project/lotus v1.26.0-rc2 h1:JPi1dofIGdN6s6kzdUSilhUCe5DIZd902TsUC7t0rog=
 github.com/filecoin-project/lotus v1.26.0-rc2/go.mod h1:6FC17T8tgqFKiTGXNAuy4HdsHcksuk0HyjWDF8my+aA=
+github.com/filecoin-project/lotus v1.26.0-rc3 h1:CynFw4VH6J2Vgpwp6/7o4kSlyQ8UQ4yAN2TCm8I6fp8=
+github.com/filecoin-project/lotus v1.26.0-rc3/go.mod h1:6FC17T8tgqFKiTGXNAuy4HdsHcksuk0HyjWDF8my+aA=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors v0.9.15-0.20220514164640-94e0d5e123bd/go.mod h1:pjGEe3QlWtK20ju/aFRsiArbMX6Cn8rqEhhsiCM9xYE=
 github.com/filecoin-project/specs-actors v0.9.15 h1:3VpKP5/KaDUHQKAMOg4s35g/syDaEBueKLws0vbsjMc=
@@ -980,6 +982,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zondax/rosetta-filecoin-lib v1.2600.0-rc1 h1:7mo+HaCA0miwKUuqewdK+9kbbgF8wwFfsX7oAUg9tOk=
 github.com/zondax/rosetta-filecoin-lib v1.2600.0-rc1/go.mod h1:Got5+dcW9v8giJdS6/xxz/mSvhfNzYXM259iEOCF+mg=
+github.com/zondax/rosetta-filecoin-lib v1.2600.0-rc3 h1:4RBp8OeJZ5PhdAaqOJnKzq8VfGtw2yxkIKUkPxCrtH8=
+github.com/zondax/rosetta-filecoin-lib v1.2600.0-rc3/go.mod h1:tI2GSMxzEmYhYHxdySg8GwUEXSkq+IcqxU7u2BedXRA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/rosetta/tests/rosetta-config-PR-calibration.json
+++ b/rosetta/tests/rosetta-config-PR-calibration.json
@@ -29,7 +29,7 @@
       "balance_tracking_disabled": false,
       "coin_tracking_disabled": false,
       "status_port": 9090,
-      "start_index": 1454318,
+      "start_index": 1453345,
       "end_conditions": {
         "index": 1454345
       }

--- a/rosetta/tests/rosetta-config-PR-calibration.json
+++ b/rosetta/tests/rosetta-config-PR-calibration.json
@@ -29,9 +29,9 @@
       "balance_tracking_disabled": false,
       "coin_tracking_disabled": false,
       "status_port": 9090,
-      "start_index": 1427008,
+      "start_index": 1454318,
       "end_conditions": {
-        "index": 1428408
+        "index": 1454345
       }
     }
   }


### PR DESCRIPTION
ClickUp: [https://app.clickup.com/t/8693rcdyd](https://app.clickup.com/t/8693rcdyd)

- Upgrade lotus to v1.26.0-rc3
- Upgrade rosetta-filecoin-lib to v1.2600.0-rc3