### PR TITLE
test: widen calibration block range to span available light-node history

### DIFF
--- a/rosetta/tests/rosetta-config-PR-calibration.json
+++ b/rosetta/tests/rosetta-config-PR-calibration.json
@@ -29,9 +29,9 @@
     "balance_tracking_disabled": false,
     "coin_tracking_disabled": false,
     "status_port": 9090,
-    "start_index": 3686300,
+    "start_index": 3686200,
     "end_conditions": {
-      "index": 3686800
+      "index": 3688400
     }
   }
 }


### PR DESCRIPTION
## Summary

Widens the rosetta-cli `check:data` calibration test range now that the calib-next light node has accumulated more history.

| | Before (PR #320) | After (this PR) |
|--|--|--|
| start_index | 3686300 | **3686200** |
| end_index   | 3686800 | **3688400** |
| range size  | 500 blocks | **2200 blocks** |

## Why this is the widest safe range right now

| Constraint | Value |
|------------|-------|
| Snapshot import height (lower block-data bound) | 3686160 — start is 40 above |
| State-tree window depth | ~head − 3000 (probed: head − 3000 OK, head − 5000 FAIL) |
| Current calibnet-next head | ~3688474 — end is 74 below |
| NV28 (FireHorse) activation | 3694534 — range entirely below |

start − 1 = 3686199 stays within the state-tree window (head − 3000 = 3685474), so `Filecoin.ChainGetParentMessages` resolves for every parent.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: cut a `v1.3600.0-rc1.1` patch tag (or fold into the next RC) — TBD