### PR TITLE
Support lotus v1.36.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/filecoin-project/go-f3 v0.8.13
 	github.com/filecoin-project/go-jsonrpc v0.10.1
 	github.com/filecoin-project/go-state-types v0.18.0
-	github.com/filecoin-project/lotus v1.36.0-rc1
+	github.com/filecoin-project/lotus v1.36.0
 	github.com/filecoin-project/specs-actors/v8 v8.0.1
 	github.com/google/uuid v1.6.0
 	github.com/ipfs/go-block-format v0.2.3
@@ -20,7 +20,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/stretchr/testify v1.11.1
-	github.com/zondax/rosetta-filecoin-lib v1.3600.0-rc1
+	github.com/zondax/rosetta-filecoin-lib v1.3600.0
 	gotest.tools v2.2.0+incompatible
 )
 
@@ -29,7 +29,7 @@ require (
 	github.com/GeertJohan/go.rice v1.0.3 // indirect
 	github.com/akavel/rsrc v0.8.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/daaku/go.zipexe v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -176,8 +176,8 @@ github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psS
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.18.0 h1:oDcjihXRlf2cM176atZzllp79Zc+kcbiuQM9DPL/1a4=
 github.com/filecoin-project/go-state-types v0.18.0/go.mod h1:CcyG4ZQRDWW+QUY2WDf1KtVDRN7W4twjsfgnGbQfJVI=
-github.com/filecoin-project/lotus v1.36.0-rc1 h1:1qOxGq3+9XTyNt51gKuCjfS5T59+mZzf1cyBNxCEevo=
-github.com/filecoin-project/lotus v1.36.0-rc1/go.mod h1:tzFOxSSszbfgocCRMsAraa9C3Jj3iEIEiOY9Pf9CsmY=
+github.com/filecoin-project/lotus v1.36.0 h1:Rw8SSZ7obavxC0sBm9EpAvXv+ggqNcDNNMmdV0my2Bs=
+github.com/filecoin-project/lotus v1.36.0/go.mod h1:tzFOxSSszbfgocCRMsAraa9C3Jj3iEIEiOY9Pf9CsmY=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors v0.9.15-0.20220514164640-94e0d5e123bd/go.mod h1:pjGEe3QlWtK20ju/aFRsiArbMX6Cn8rqEhhsiCM9xYE=
 github.com/filecoin-project/specs-actors v0.9.15 h1:3VpKP5/KaDUHQKAMOg4s35g/syDaEBueKLws0vbsjMc=
@@ -862,8 +862,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zondax/rosetta-filecoin-lib v1.3600.0-rc1 h1:VKSnnolf2xQonfs2HRiveDWLX8dYFUd2IbSCtBdtrMI=
-github.com/zondax/rosetta-filecoin-lib v1.3600.0-rc1/go.mod h1:9FbwFzashBX71P+GoePCtVI5xiwtCO852y/Kryk8jVs=
+github.com/zondax/rosetta-filecoin-lib v1.3600.0 h1:7gUaOOnfWdLo5JxfrZAFwo1mCkzAt6js4suxBgD6EXI=
+github.com/zondax/rosetta-filecoin-lib v1.3600.0/go.mod h1:wMCnDndFcfU/5EdZtFfW/xpNgkfdDZq8n9Sb7tYFilw=
 gitlab.com/yawning/secp256k1-voi v0.0.0-20230925100816-f2616030848b h1:CzigHMRySiX3drau9C6Q5CAbNIApmLdat5jPMqChvDA=
 gitlab.com/yawning/secp256k1-voi v0.0.0-20230925100816-f2616030848b/go.mod h1:/y/V339mxv2sZmYYR64O07VuCpdNZqCTwO8ZcouTMI8=
 gitlab.com/yawning/tuplehash v0.0.0-20230713102510-df83abbf9a02 h1:qwDnMxjkyLmAFgcfgTnfJrmYKWhHnci3GjDqcZp1M3Q=


### PR DESCRIPTION
## Summary

Bumps lotus from `v1.36.0-rc1` to the stable `v1.36.0` release, paired with the matching `rosetta-filecoin-lib` tag bump from `v1.3600.0-rc1` to `v1.3600.0`. Second leg of the lib → proxy release cycle for NV28 ("Fire Horse") — mandatory mainnet upgrade at epoch **6052800 / 2026-05-27T14:00:00Z**.

## What changed

Two `require` lines in `go.mod` plus matching `go.sum` hashes. That's it:

```diff
-	github.com/filecoin-project/lotus v1.36.0-rc1
+	github.com/filecoin-project/lotus v1.36.0
-	github.com/zondax/rosetta-filecoin-lib v1.3600.0-rc1
+	github.com/zondax/rosetta-filecoin-lib v1.3600.0
```

`go mod tidy` also incidentally bumped `github.com/buger/jsonparser` `1.1.1 → 1.1.2` (transitive through the lib).

## What did NOT change

| Check | State |
|-------|-------|
| Go directive | `1.25.7` — already matches lotus's `go.mod` |
| `.github/workflows/main.yml` Go version | Unchanged (directive didn't move) |
| `extern/filecoin-ffi` submodule pointer | Unchanged |
| `tests/mocks/full_node_mock.go` + `rosetta/services/mocks/full_node_mock.go` | Unchanged — lotus's `FullNode` interface is identical between rc1 and stable (verified `git diff v1.36.0-rc1..v1.36.0 -- api/api_full.go` in upstream lotus → empty diff) |
| `rosetta/tests/rosetta-config-PR-calibration.json` | Unchanged — block range already valid for the calibration network at this lotus version (set by #321) |

## Upstream rc1 → stable diff (FYI)

4 commits in lotus, none touching the FullNode RPC API surface:

1. `c7e3b7e` (#13617) — eth filter cap behavior; doesn't affect proxy.
2. `75d7758` (#13620) — chain/sync.go nil-guard; internal.
3. `92ec445` (#13619) — mainnet `UpgradeFireHorseHeight = 6052800` build constant.
4. `154c0c3` — version + CHANGELOG.

## Paired with

- [Zondax/rosetta-filecoin-lib#210](https://github.com/Zondax/rosetta-filecoin-lib/pull/210) — merged, tag `v1.3600.0` published.

## Test plan

- [ ] `build` job green.
- [ ] `Rosetta CLI integration tests (calibration)` green against `LOTUS_CALIBRATION_RPC_URL` running lotus v1.36.0 (or rc1 — wire-compatible, same FullNode interface).
- [ ] After merge, tag `v1.3600.0` + `gh release create` to publish.

## Follow-ups (after merge)

- Tag `v1.3600.0` and create GH release.
- Roll calib/mainnet image bumps in `project-filecoin` (PRs #1141–#1144 already open for calibration archival on pro).