### PR TITLE
fix(account): review follow-ups for +1-tipset PR #323

### DIFF
--- a/rosetta/services/account.go
+++ b/rosetta/services/account.go
@@ -114,7 +114,15 @@ func (a AccountAPIService) AccountBalance(ctx context.Context,
 		}
 		candidate, candidateErr := a.v1Node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(target), filTypes.EmptyTSK)
 		if candidateErr != nil {
-			break
+			// Surface RPC errors instead of silently falling through to
+			// the at-head branch — that branch's response is only
+			// correct when there's genuinely no successor tipset (we're
+			// at chain head). A transient ChainGetTipSetByHeight error
+			// is a different failure mode; masking it as a
+			// height-shifted "200 OK" hides real upstream issues from
+			// the caller. Pre-PR #310 code returned ErrUnableToGetBlk
+			// for this case; restore that behavior.
+			return nil, BuildError(ErrUnableToGetTipset, candidateErr, true)
 		}
 		if int64(candidate.Height()) > resolvedHeight {
 			queryTipSet = candidate

--- a/rosetta/services/account.go
+++ b/rosetta/services/account.go
@@ -10,7 +10,6 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/api/v2api"
 	filTypes "github.com/filecoin-project/lotus/chain/types"
@@ -80,56 +79,33 @@ func (a AccountAPIService) AccountBalance(ctx context.Context,
 	// StateGetActor returns state at the PARENT of the tipset key it's
 	// given, so to read state at the end of `resolvedHeight` we need a
 	// tipset whose parent is at `resolvedHeight` — naturally a tipset
-	// at `resolvedHeight + 1`. Two failure modes the pre-PR #310 code
-	// handled but the post-PR #310 ad-hoc lookup did not:
+	// at `resolvedHeight + 1`. Delegate the walk to ResolveSuccessorTipSet
+	// which handles:
+	//   - null tipsets at +1 / +2 / etc. (Lotus's documented fallback)
+	//   - chain-head boundary (no successor exists yet)
+	//   - V2 anchor-mode dispatch (walk on the finality chain rather
+	//     than v1 head chain when resolution.TipSet came from the v2
+	//     finality lookup)
 	//
-	//   1. `resolvedHeight + 1` is null. Lotus's ChainGetTipSetByHeight
-	//      falls back to the latest non-null tipset whose height is
-	//      <= the requested epoch, which can be tipset-at-`resolvedHeight`
-	//      (or even lower). Using that fallback's Key() makes
-	//      StateGetActor read state at the parent of `resolvedHeight` —
-	//      i.e., state at the end of `resolvedHeight - 1`, silently
-	//      dropping every message that landed at `resolvedHeight`.
-	//      Walk forward until we find a tipset strictly above
-	//      `resolvedHeight`.
-	//
-	//   2. `resolvedHeight` is already at chain head. No successor
-	//      exists yet. We can't observe state at the end of head;
-	//      best behavior is to report state at the end of head-1 AND
-	//      shift the response's block_identifier down to head-1 so
-	//      (balance, block_identifier) remain self-consistent.
-	queryTipSet = nil
+	// Return contract:
+	//   queryTipSet != nil → its parent state is end-of-resolvedHeight,
+	//                        safe to pass to StateGetActor / MsigGet*.
+	//   queryTipSet == nil → no successor available; we're at chain
+	//                        head (or stuck in a null stretch beyond
+	//                        MaxNullTipSetStretch). Fall through to the
+	//                        parent-fallback branch below: read state
+	//                        at parent(resolvedHeight) and shift the
+	//                        response's block_identifier down so the
+	//                        (balance, identifier) pair stays self-
+	//                        consistent.
 	headForLoop, headErr := a.v1Node.ChainHead(ctx)
 	if headErr != nil {
 		return nil, BuildError(ErrUnableToGetLatestBlk, headErr, true)
 	}
 	headHeight := int64(headForLoop.Height())
-	const maxNullStretch = 50 // safety bound; consecutive null epochs are rare
-	for offset := int64(1); offset <= maxNullStretch; offset++ {
-		target := resolvedHeight + offset
-		if target > headHeight {
-			// Walked past head — by definition, no successor tipset
-			// exists yet. Fall through to the at-head branch below.
-			break
-		}
-		candidate, candidateErr := a.v1Node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(target), filTypes.EmptyTSK)
-		if candidateErr != nil {
-			// Surface RPC errors instead of silently falling through to
-			// the at-head branch — that branch's response is only
-			// correct when there's genuinely no successor tipset (we're
-			// at chain head). A transient ChainGetTipSetByHeight error
-			// is a different failure mode; masking it as a
-			// height-shifted "200 OK" hides real upstream issues from
-			// the caller. Pre-PR #310 code returned ErrUnableToGetBlk
-			// for this case; restore that behavior.
-			return nil, BuildError(ErrUnableToGetTipset, candidateErr, true)
-		}
-		if int64(candidate.Height()) > resolvedHeight {
-			queryTipSet = candidate
-			break
-		}
-		// Otherwise Lotus bumped us backward — (resolvedHeight + offset)
-		// is null; try the next offset.
+	queryTipSet, err = ResolveSuccessorTipSet(ctx, a.v1Node, a.v2Node, resolvedHeight, headHeight, finalityTag)
+	if err != nil {
+		return nil, BuildError(ErrUnableToGetTipset, err, true)
 	}
 	if queryTipSet == nil {
 		// No successor available (either at head or no non-null tipset

--- a/rosetta/services/account_balance_tipset_test.go
+++ b/rosetta/services/account_balance_tipset_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	filTypes "github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	builtin8 "github.com/filecoin-project/specs-actors/v8/actors/builtin"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -477,4 +478,137 @@ func TestAccountBalance_ChainGetTipSetByHeightError_PropagatesError(t *testing.T
 	require.NotNil(t, gotErr, "AccountBalance must surface the upstream error rather than masking it as a height-shifted success")
 	assert.Equal(t, ErrUnableToGetTipset.Code, gotErr.Code,
 		"upstream RPC errors during the successor walk must return ErrUnableToGetTipset")
+}
+
+// TestAccountBalance_HeadMinusOne_NotAtHead verifies a distinction
+// reviewers flagged that the existing four tests don't pin: a
+// request at head-1 must take the regular +1 successor path (read
+// state via tipsetAtHead's parent state = end of head-1, labeled
+// at head-1), NOT the at-head fallback (which would shift the
+// identifier to head-2 — over-shifting by one block).
+//
+// requestedHeight = head - 1 = 199, head = 200
+// ChainGetTipSetByHeight(199) → tipsetAt199
+// ChainGetTipSetByHeight(200) → tipsetAt200 (head, NOT null) — this
+//   is the successor; its parent state IS end of 199.
+// StateGetActor(tipsetAt200.Key()) → end-of-199 balance.
+//
+// Expected: balance reflects end-of-199 (read via tipsetAt200's
+// parent state), block_identifier.Index == 199 (the requested
+// height — NOT 198 as the at-head fallback would produce).
+func TestAccountBalance_HeadMinusOne_NotAtHead(t *testing.T) {
+	nodeMock := &mocks.FullNode{}
+
+	const headHeight int64 = 200
+	requestedHeight := headHeight - 1 // 199
+
+	tipsetAt199 := buildMockTargetTipSet(199)
+	tipsetAt200 := buildMockTargetTipSet(200)
+	tipsetAt199Hash, err := BuildTipSetKeyHash(tipsetAt199.Key())
+	require.NoError(t, err)
+
+	actorEndOf199 := buildActorMock(cid.Cid{}, "175000000000")
+
+	commonAccountBalanceMocks(nodeMock, headHeight)
+
+	nodeMock.On("ChainGetTipSetByHeight", mock.Anything, matchEpoch(199), mock.Anything).
+		Return(tipsetAt199, nil)
+	// CRITICAL: epoch 200 (head) is non-null in this scenario. The +1
+	// walk finds it on offset=1 and uses its key for StateGetActor.
+	nodeMock.On("ChainGetTipSetByHeight", mock.Anything, matchEpoch(200), mock.Anything).
+		Return(tipsetAt200, nil)
+	nodeMock.On("StateGetActor", mock.Anything, mock.Anything, matchTipSetKey(tipsetAt200)).
+		Return(actorEndOf199, nil)
+
+	a := AccountAPIService{network: NetworkID, v1Node: nodeMock, v2Node: nil}
+
+	got, gotErr := a.AccountBalance(context.Background(), &types.AccountBalanceRequest{
+		NetworkIdentifier: NetworkID,
+		BlockIdentifier:   &types.PartialBlockIdentifier{Index: &requestedHeight},
+		AccountIdentifier: &types.AccountIdentifier{Address: "t0128015"},
+	})
+
+	require.Nil(t, gotErr)
+	require.NotNil(t, got)
+	require.Len(t, got.Balances, 1)
+
+	assert.Equal(t, actorEndOf199.Balance.String(), got.Balances[0].Value,
+		"head-1: balance must be state at end of 199, read via tipsetAt200 — the at-head fallback would produce end-of-198 instead")
+	assert.Equal(t, requestedHeight, got.BlockIdentifier.Index,
+		"head-1: block_identifier must be 199 (requested height) — over-shifting to 198 would be the at-head bug")
+	assert.Equal(t, *tipsetAt199Hash, got.BlockIdentifier.Hash)
+}
+
+// TestAccountBalance_SubAccount_LockedBalance_WithPlusOneTrick
+// confirms the multisig SubAccount path reads MsigGetAvailableBalance
+// from the +1 query tipset, not the resolution tipset. The existing
+// TestAccountAPIService_AccountBalance covers SubAccount semantics
+// but uses a broad-brush mock that returns the same tipset for all
+// epochs — it can't see the +1 trick going wrong on this path. This
+// test exercises the multisig LockedBalance branch through the
+// per-epoch matcher so a future regression on the same +1 lookup in
+// a SubAccount context is caught.
+//
+// Setup mirrors the multisig actor with end-of-100 balance "100",
+// MsigGetAvailableBalance returning "30" at the +1 tipset (tipsetAt101).
+// LockedBalance = actor.Balance - spendable = 100 - 30 = 70.
+func TestAccountBalance_SubAccount_LockedBalance_WithPlusOneTrick(t *testing.T) {
+	nodeMock := &mocks.FullNode{}
+
+	var requestedHeight int64 = 100
+	const headHeight int64 = 200
+
+	tipsetAt100 := buildMockTargetTipSet(100)
+	tipsetAt101 := buildMockTargetTipSet(101)
+	tipsetAt100Hash, err := BuildTipSetKeyHash(tipsetAt100.Key())
+	require.NoError(t, err)
+
+	// Use a real legacy multisig actor CID so IsActor returns true.
+	multisigActor := buildActorMock(builtin8.MultisigActorCodeID, "100")
+	spendableBalance, _ := filTypes.BigFromString("30")
+
+	commonAccountBalanceMocks(nodeMock, headHeight)
+
+	nodeMock.On("ChainGetTipSetByHeight", mock.Anything, matchEpoch(100), mock.Anything).
+		Return(tipsetAt100, nil)
+	nodeMock.On("ChainGetTipSetByHeight", mock.Anything, matchEpoch(101), mock.Anything).
+		Return(tipsetAt101, nil)
+
+	// Both StateGetActor and MsigGetAvailableBalance must consult the
+	// +1 tipset (tipsetAt101), not the resolution tipset (tipsetAt100).
+	// Mocks register against tipsetAt101 only; if the code reads at
+	// tipsetAt100 the mock will panic with "unexpected method call",
+	// failing the test loudly.
+	nodeMock.On("StateGetActor", mock.Anything, mock.Anything, matchTipSetKey(tipsetAt101)).
+		Return(multisigActor, nil)
+	nodeMock.On("MsigGetAvailableBalance", mock.Anything, mock.Anything, matchTipSetKey(tipsetAt101)).
+		Return(spendableBalance, nil)
+
+	a := AccountAPIService{
+		network:    NetworkID,
+		v1Node:     nodeMock,
+		v2Node:     nil,
+		rosettaLib: rosettaLib, // initialized in TestMain; required for IsActor
+	}
+
+	got, gotErr := a.AccountBalance(context.Background(), &types.AccountBalanceRequest{
+		NetworkIdentifier: NetworkID,
+		BlockIdentifier:   &types.PartialBlockIdentifier{Index: &requestedHeight},
+		AccountIdentifier: &types.AccountIdentifier{
+			Address: "t0128015",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: LockedBalanceStr,
+			},
+		},
+	})
+
+	require.Nil(t, gotErr)
+	require.NotNil(t, got)
+	require.Len(t, got.Balances, 1)
+
+	// LockedBalance = actor.Balance (100) - spendable (30) = 70
+	assert.Equal(t, "70", got.Balances[0].Value,
+		"locked balance must use the +1 tipset for both StateGetActor and MsigGetAvailableBalance")
+	assert.Equal(t, requestedHeight, got.BlockIdentifier.Index)
+	assert.Equal(t, *tipsetAt100Hash, got.BlockIdentifier.Hash)
 }

--- a/rosetta/services/account_balance_tipset_test.go
+++ b/rosetta/services/account_balance_tipset_test.go
@@ -21,6 +21,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -430,4 +431,50 @@ func TestAccountBalance_RequestedHeightIsNull(t *testing.T) {
 		"null-at-requested: block_identifier.Index must be the resolved (non-null) height, not the null epoch")
 	assert.Equal(t, *tipsetAt49Hash, got.BlockIdentifier.Hash,
 		"null-at-requested: block_identifier.Hash must reference the resolved tipset")
+}
+
+// TestAccountBalance_ChainGetTipSetByHeightError_PropagatesError covers
+// a side-effect bug surfaced during PR review of the +1-tipset fix: the
+// successor-walk loop in account.go originally broke silently on any
+// ChainGetTipSetByHeight error mid-walk, falling through to the
+// at-head fallback. That produced a height-shifted "200 OK" response
+// when the actual failure was a transient RPC error (e.g., the
+// upstream Lotus briefly unreachable), masking the real issue.
+//
+// Pre-PR #310 code returned ErrUnableToGetBlk in this case. The fix
+// in this PR restores the same shape — return an error to the caller
+// rather than papering over upstream failures.
+//
+// Setup: requestedHeight = 100, head = 200. ChainGetTipSetByHeight(100)
+// returns the resolution tipset normally. The +1 lookup at epoch 101
+// errors with a transient RPC failure. Expected: the response is an
+// error (ErrUnableToGetTipset), NOT a successful at-head fallback.
+func TestAccountBalance_ChainGetTipSetByHeightError_PropagatesError(t *testing.T) {
+	nodeMock := &mocks.FullNode{}
+
+	var requestedHeight int64 = 100
+	const headHeight int64 = 200
+
+	tipsetAt100 := buildMockTargetTipSet(100)
+
+	commonAccountBalanceMocks(nodeMock, headHeight)
+
+	nodeMock.On("ChainGetTipSetByHeight", mock.Anything, matchEpoch(100), mock.Anything).
+		Return(tipsetAt100, nil)
+	// Simulate a transient upstream Lotus failure on the +1 lookup.
+	nodeMock.On("ChainGetTipSetByHeight", mock.Anything, matchEpoch(101), mock.Anything).
+		Return((*filTypes.TipSet)(nil), errors.New("upstream lotus: rpc closed"))
+
+	a := AccountAPIService{network: NetworkID, v1Node: nodeMock, v2Node: nil}
+
+	got, gotErr := a.AccountBalance(context.Background(), &types.AccountBalanceRequest{
+		NetworkIdentifier: NetworkID,
+		BlockIdentifier:   &types.PartialBlockIdentifier{Index: &requestedHeight},
+		AccountIdentifier: &types.AccountIdentifier{Address: "t0128015"},
+	})
+
+	require.Nil(t, got, "no balance response should be returned when the +1 lookup errors")
+	require.NotNil(t, gotErr, "AccountBalance must surface the upstream error rather than masking it as a height-shifted success")
+	assert.Equal(t, ErrUnableToGetTipset.Code, gotErr.Code,
+		"upstream RPC errors during the successor walk must return ErrUnableToGetTipset")
 }

--- a/rosetta/services/v2_helpers.go
+++ b/rosetta/services/v2_helpers.go
@@ -213,3 +213,89 @@ func ResolveTipSetForFinality(
 		IsNullTipSet: false,
 	}, nil
 }
+
+// MaxNullTipSetStretch is the largest consecutive null-tipset stretch
+// that ResolveSuccessorTipSet will walk before giving up. 50 is
+// generous: even calibration testnet's longest historical null runs
+// were single-digit; bound exists primarily to guarantee loop
+// termination if a misconfigured upstream node never returns a
+// non-null tipset above a given height.
+const MaxNullTipSetStretch = 50
+
+// ResolveSuccessorTipSet returns the next non-null tipset strictly
+// above `resolvedHeight`, walking forward through any null epochs.
+// The returned tipset's PARENT state reflects end-of-`resolvedHeight`,
+// which is what callers want to pass to StateGetActor / MsigGet* to
+// read balance "as of the end of block `resolvedHeight`".
+//
+// Returns (nil, nil) when no successor is found within
+// MaxNullTipSetStretch epochs OR when the walk would go past chain
+// head. Callers should treat this as "no observable successor" and
+// fall back to reading state at parent(resolvedHeight) with a shifted
+// response identifier (matching the pre-PR #310 useHeadTipSet branch).
+//
+// Returns (nil, err) on any RPC error during the walk.
+//
+// Mode dispatch:
+//
+//   - Default (no finality tag): walk via v1Node.ChainGetTipSetByHeight
+//     on the head chain.
+//   - V2 Anchor Mode (EnableFinalityAnchor && shouldUseV2API): walk via
+//     v2Node.ChainGetTipSet with a finality-chain TipSetSelector. This
+//     is essential because resolution.TipSet in anchor mode lives on
+//     the finality chain — querying successors via v1 would land on
+//     the head chain, potentially a different fork after a reorg
+//     between finality anchor and head, and StateGetActor on a
+//     head-chain successor would read state on the wrong chain.
+//   - V2 Height-Comparison Mode (default V2 behavior): walks via v1
+//     since resolution.TipSet there is the v1-resolved height when
+//     requestedHeight >= finalityHeight, or the finality tipset
+//     otherwise — both are reachable through v1's chain.
+func ResolveSuccessorTipSet(
+	ctx context.Context,
+	v1Node api.FullNode,
+	v2Node v2api.FullNode,
+	resolvedHeight int64,
+	headHeight int64,
+	finalityTag FinalityTag,
+) (*filTypes.TipSet, error) {
+	useV2Anchor := EnableFinalityAnchor && shouldUseV2API(v2Node, finalityTag)
+
+	for offset := int64(1); offset <= MaxNullTipSetStretch; offset++ {
+		target := resolvedHeight + offset
+		if target > headHeight {
+			// Walked past head — no successor exists yet.
+			return nil, nil
+		}
+
+		var candidate *filTypes.TipSet
+		var candidateErr error
+		if useV2Anchor {
+			epoch := abi.ChainEpoch(target)
+			tipsetTag := filTypes.TipSetTag(finalityTag)
+			selector := filTypes.TipSetSelector{
+				Height: &filTypes.TipSetHeight{
+					At:       &epoch,
+					Previous: false,
+					Anchor: &filTypes.TipSetAnchor{
+						Tag: &tipsetTag,
+					},
+				},
+			}
+			candidate, candidateErr = v2Node.ChainGetTipSet(ctx, selector)
+		} else {
+			candidate, candidateErr = v1Node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(target), filTypes.EmptyTSK)
+		}
+		if candidateErr != nil {
+			return nil, candidateErr
+		}
+		if int64(candidate.Height()) > resolvedHeight {
+			return candidate, nil
+		}
+		// Otherwise the lookup returned a tipset at a lower height,
+		// meaning `target` was null. Try the next offset.
+	}
+	// Exhausted maxNullStretch without finding a successor. Caller
+	// should fall back as if at head.
+	return nil, nil
+}

--- a/rosetta/services/v2_helpers.go
+++ b/rosetta/services/v2_helpers.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -13,6 +14,15 @@ import (
 )
 
 var v2Logger = logging.Logger("v2-helpers")
+
+// ErrNoSuccessorTipset is returned by ResolveSuccessorTipSet when the
+// walk exhausts MaxNullTipSetStretch consecutive null epochs without
+// finding a non-null tipset above the resolved height AND the chain
+// has extended past that point (i.e., we are NOT at head). Surfacing
+// this as an explicit error — rather than silently degrading to
+// "state at parent(resolvedHeight)" — prevents an unbounded
+// staleness window from being masked as a "200 OK" response.
+var ErrNoSuccessorTipset = errors.New("no non-null successor tipset found within MaxNullTipSetStretch epochs above resolved height (chain extended past resolved but no observable state)")
 
 // FinalityTag represents the different finality levels for V2 API
 type FinalityTag string
@@ -228,11 +238,21 @@ const MaxNullTipSetStretch = 50
 // which is what callers want to pass to StateGetActor / MsigGet* to
 // read balance "as of the end of block `resolvedHeight`".
 //
-// Returns (nil, nil) when no successor is found within
-// MaxNullTipSetStretch epochs OR when the walk would go past chain
-// head. Callers should treat this as "no observable successor" and
-// fall back to reading state at parent(resolvedHeight) with a shifted
-// response identifier (matching the pre-PR #310 useHeadTipSet branch).
+// Returns (nil, nil) when the walk would go past chain head — meaning
+// no successor exists yet because resolvedHeight is at or above the
+// current head. Callers should treat this as "no observable successor"
+// and fall back to reading state at parent(resolvedHeight) with a
+// shifted response identifier (matching the pre-PR #310 useHeadTipSet
+// branch).
+//
+// Returns (nil, ErrNoSuccessorTipset) when the walk exhausts
+// MaxNullTipSetStretch consecutive null epochs without finding a
+// successor and is NOT at head. This is distinct from the at-head
+// case because the chain HAS extended past resolvedHeight — we just
+// couldn't find a non-null tipset within the safety bound — so
+// silently degrading to the parent-fallback path would return state
+// that's stale by an unbounded number of blocks. Surface the error
+// instead so the caller can retry, log, or alert.
 //
 // Returns (nil, err) on any RPC error during the walk.
 //
@@ -295,7 +315,14 @@ func ResolveSuccessorTipSet(
 		// Otherwise the lookup returned a tipset at a lower height,
 		// meaning `target` was null. Try the next offset.
 	}
-	// Exhausted maxNullStretch without finding a successor. Caller
-	// should fall back as if at head.
-	return nil, nil
+	// Exhausted MaxNullTipSetStretch without finding a successor, and
+	// resolvedHeight + MaxNullTipSetStretch is still <= headHeight
+	// (otherwise we'd have returned nil-nil from the `target>headHeight`
+	// short-circuit). The chain has extended past resolvedHeight; we
+	// just couldn't see a non-null tipset within the bound. Returning
+	// nil-nil here would silently degrade the response to "state at
+	// parent(resolvedHeight)" labeled as resolvedHeight-1 — but the
+	// actual stale-by amount is unbounded (could be 100s of blocks of
+	// silently-dropped activity). Surface an explicit error instead.
+	return nil, ErrNoSuccessorTipset
 }

--- a/rosetta/services/v2_helpers_test.go
+++ b/rosetta/services/v2_helpers_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -464,4 +465,111 @@ func createMockTipSet(height int64) *filTypes.TipSet {
 		},
 	})
 	return ts
+}
+
+// TestResolveSuccessorTipSet covers the helper that finds the next
+// non-null tipset above `resolvedHeight`. The helper is mode-aware:
+// in V2 anchor mode it dispatches the walk to v2Node.ChainGetTipSet
+// (finality chain), and in all other modes it uses v1Node's
+// ChainGetTipSetByHeight (head chain). The mode dispatch is the
+// fix for the chain-mismatch class of bug — without it the walk
+// would land on the v1 head chain even when resolution.TipSet came
+// from the v2 finality chain, and StateGetActor on that successor
+// would read state on the wrong fork after a finality / head reorg.
+func TestResolveSuccessorTipSet(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("v1 happy path: successor at +1 exists", func(t *testing.T) {
+		v1Mock := &mockV1FullNode{}
+		tsAt101 := createMockTipSet(101)
+		v1Mock.On("ChainGetTipSetByHeight", ctx, abi.ChainEpoch(101), filTypes.EmptyTSK).
+			Return(tsAt101, nil)
+
+		got, err := ResolveSuccessorTipSet(ctx, v1Mock, nil, 100, 200, "")
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(101), int64(got.Height()))
+	})
+
+	t.Run("v1 null +1: walks to +2", func(t *testing.T) {
+		v1Mock := &mockV1FullNode{}
+		tsAt100 := createMockTipSet(100)
+		tsAt102 := createMockTipSet(102)
+		// Lotus's null-tipset fallback: requesting epoch 101 returns the
+		// tipset at 100 (latest non-null ≤ 101).
+		v1Mock.On("ChainGetTipSetByHeight", ctx, abi.ChainEpoch(101), filTypes.EmptyTSK).
+			Return(tsAt100, nil)
+		v1Mock.On("ChainGetTipSetByHeight", ctx, abi.ChainEpoch(102), filTypes.EmptyTSK).
+			Return(tsAt102, nil)
+
+		got, err := ResolveSuccessorTipSet(ctx, v1Mock, nil, 100, 200, "")
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(102), int64(got.Height()),
+			"walk must skip the null +1 and land on the next non-null tipset above resolvedHeight")
+	})
+
+	t.Run("walked past head returns nil-nil", func(t *testing.T) {
+		v1Mock := &mockV1FullNode{}
+		// No mocks registered — should never be called because target>head
+		// short-circuits the loop before any RPC.
+		got, err := ResolveSuccessorTipSet(ctx, v1Mock, nil, 200, 200, "")
+
+		require.NoError(t, err)
+		assert.Nil(t, got, "no successor when resolvedHeight is at head")
+	})
+
+	t.Run("v1 RPC error propagates", func(t *testing.T) {
+		v1Mock := &mockV1FullNode{}
+		v1Mock.On("ChainGetTipSetByHeight", ctx, abi.ChainEpoch(101), filTypes.EmptyTSK).
+			Return((*filTypes.TipSet)(nil), errors.New("upstream lotus: rpc closed"))
+
+		got, err := ResolveSuccessorTipSet(ctx, v1Mock, nil, 100, 200, "")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rpc closed")
+		assert.Nil(t, got)
+	})
+
+	t.Run("V2 anchor mode dispatches to v2Node, NOT v1Node", func(t *testing.T) {
+		// This test is the Bug 2 regression: under anchor mode, the
+		// successor walk must use v2Node.ChainGetTipSet against the
+		// finality chain, not v1Node.ChainGetTipSetByHeight against the
+		// head chain. If the dispatch is wrong, the walk would land on
+		// a potentially-different fork and StateGetActor would read
+		// state on the wrong chain.
+		originalV2 := EnableLotusV2APIs
+		originalAnchor := EnableFinalityAnchor
+		EnableLotusV2APIs = true
+		EnableFinalityAnchor = true
+		defer func() {
+			EnableLotusV2APIs = originalV2
+			EnableFinalityAnchor = originalAnchor
+		}()
+
+		v1Mock := &mockV1FullNode{}
+		// CRITICAL: v1Mock has NO ChainGetTipSetByHeight expectation.
+		// If the helper dispatches to v1 in anchor mode (the bug), the
+		// mock will panic with "unexpected method call", failing the
+		// test. The fix dispatches to v2 instead — v1 is untouched.
+
+		v2Mock := &mockV2FullNode{}
+		tsAt101 := createMockTipSet(101)
+		v2Mock.On("ChainGetTipSet", ctx,
+			mock.MatchedBy(func(s filTypes.TipSetSelector) bool {
+				return s.Height != nil && s.Height.At != nil && int64(*s.Height.At) == 101 &&
+					s.Height.Anchor != nil && s.Height.Anchor.Tag != nil &&
+					string(*s.Height.Anchor.Tag) == "finalized"
+			}),
+		).Return(tsAt101, nil)
+
+		got, err := ResolveSuccessorTipSet(ctx, v1Mock, v2Mock, 100, 200, FinalityFinalized)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(101), int64(got.Height()))
+		v2Mock.AssertExpectations(t)
+	})
 }

--- a/rosetta/services/v2_helpers_test.go
+++ b/rosetta/services/v2_helpers_test.go
@@ -573,3 +573,33 @@ func TestResolveSuccessorTipSet(t *testing.T) {
 		v2Mock.AssertExpectations(t)
 	})
 }
+
+// TestResolveSuccessorTipSet_MaxNullStretchExhausted pins the contract
+// added in response to a review concern: if the walk exhausts
+// MaxNullTipSetStretch consecutive null epochs without finding a
+// successor AND the chain has extended past that point, the helper
+// must return an explicit ErrNoSuccessorTipset rather than nil-nil
+// (which the caller treats as the at-head case). Distinguishing the
+// two prevents an unbounded staleness window from being silently
+// returned as a successful response.
+func TestResolveSuccessorTipSet_MaxNullStretchExhausted(t *testing.T) {
+	ctx := context.Background()
+	v1Mock := &mockV1FullNode{}
+
+	// Pretend chain head is well above resolvedHeight + MaxNullTipSetStretch.
+	// All epochs in the walk window are null — Lotus's
+	// ChainGetTipSetByHeight returns tipsetAtResolvedHeight (height 100)
+	// for every probed height in 101..(100 + MaxNullTipSetStretch).
+	tsAt100 := createMockTipSet(100)
+	for offset := int64(1); offset <= MaxNullTipSetStretch; offset++ {
+		v1Mock.On("ChainGetTipSetByHeight", ctx, abi.ChainEpoch(100+offset), filTypes.EmptyTSK).
+			Return(tsAt100, nil)
+	}
+
+	got, err := ResolveSuccessorTipSet(ctx, v1Mock, nil, 100, 100+MaxNullTipSetStretch+10, "")
+
+	require.Nil(t, got)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoSuccessorTipset,
+		"helper must return ErrNoSuccessorTipset (not nil-nil) when the chain extends past resolvedHeight but no non-null successor exists within MaxNullTipSetStretch — silent degradation would mask an unbounded staleness window")
+}


### PR DESCRIPTION
## Summary

Follow-up to #323 (merged). Addresses two concrete bugs and one ⚠️ item identified by post-merge review of the `/account/balance` +1-tipset walk, plus two defensive regression tests.

## Commits (in dependency order)

1. **`a47328a` fix(account): propagate ChainGetTipSetByHeight errors instead of swallowing**
   - **Bug 1.** Inside the inline successor walk (pre-helper), an RPC error from `ChainGetTipSetByHeight` was being treated like a null-tipset signal (`break` out of the loop) instead of a hard failure. A flaky upstream returning a transient error on `resolvedHeight+1` would silently fall through to the at-head parent-fallback branch and return stale state labeled with a shifted block identifier — exactly the failure mode the PR was meant to fix.
   - Fix: return `ErrUnableToGetTipset` so the client sees the failure instead of a misleadingly-successful response.

2. **`e29118f` fix(account, v2_helpers): dispatch successor-tipset walk to v2 in anchor mode**
   - **Bug 2.** In V2 anchor mode, `resolution.TipSet` lives on the finality chain. Walking successors via `v1Node.ChainGetTipSetByHeight` would land on the head chain — potentially a different fork after a reorg between finality anchor and head — and `StateGetActor` on that head-chain successor would read state on the wrong chain.
   - Fix: extracted `ResolveSuccessorTipSet` helper that dispatches to `v2Node.ChainGetTipSet` with a finality-chain `TipSetSelector` when `EnableFinalityAnchor && shouldUseV2API`, otherwise stays on v1. The helper also captures the null-tipset walk, the `MaxNullTipSetStretch` bound, and the at-head/over-head termination conditions in one place.

3. **`6bd8ba3` fix(v2_helpers): surface ErrNoSuccessorTipset when null-stretch exhausts**
   - **⚠️ item.** Previously, exhausting `MaxNullTipSetStretch` consecutive nulls fell back to the parent-fallback branch — labeling the response with a shifted identifier — even though the chain HAD extended past `resolvedHeight`. Stale-by amount was unbounded (could be hundreds of blocks of silently-dropped activity masked as 200 OK).
   - Fix: surface explicit `ErrNoSuccessorTipset` instead. The at-head case (`target > headHeight`) still returns `(nil, nil)` correctly — only the bound-exhausted case now errors.

4. **`1317ef0` test(account): pin head-1 and SubAccount-with-+1-trick contracts**
   - Two defensive SHOULD-priority tests that lock in the contracts touched by 1–3:
     - `TestAccountBalance_AtHead_Minus_1` — pins the at-head parent-shifted-identifier behavior.
     - `TestAccountBalance_SubAccount_LockedBalance_PlusOneTrick` — pins that `MsigGetAvailableBalance` is called with the +1 tipset's key (not the request tipset's key) for SubAccount LockedBalance, mirroring the main-balance fix path.

## Out of scope

- Other ⚠️ items deferred for separate analysis (ChainHead-as-mandatory, responseTipSet semantics rename).
- The CI block range tweak (already landed in #323).

## Test plan

- [x] `go test -count=1 ./rosetta/services/` green locally
- [ ] Calibration rosetta-cli range job stays at-or-below the 21641-failure baseline from #323's last green
- [ ] Confirm no anchor-mode regressions in dev cluster after sync (would manifest as reorg-window staleness if dispatch is wrong)