### PR TITLE
fix(evm): resolve account/ethaccount InvokeEVM calls via the Send fallback

### DIFF
--- a/rosetta/services/helpers.go
+++ b/rosetta/services/helpers.go
@@ -173,35 +173,45 @@ func GetMethodName(msg *filTypes.MessageTrace, lib *rosettaFilecoinLib.RosettaCo
 	}
 
 	actorName := GetActorNameFromAddress(msg.To, lib)
-	method := GetMethodByActorName(actorName)
+	return resolveMethodName(actorName, msg.Method), nil
+}
 
-	// If method is unknown check for fallback behavior
-	if method == actors.UnknownStr && isAccountActorFallback(actorName, msg.Method) {
-		// Try to find the method in all known actors
-		if methodName := FindMethodNameInAllActors(uint64(msg.Method)); methodName != actors.UnknownStr {
-			return methodName, nil
-		}
-
-		// If not found and it's an actor with fallback behavior, return METHOD_FALLBACK
-		return METHOD_FALLBACK, nil
+// resolveMethodName maps an (actorName, method) pair to a human-readable method
+// name. It first looks the method number up in the recipient actor's own method
+// set. If the method is not defined there but is an exported (FRC-42 range)
+// method sent to an account/ethaccount actor, it is reported as the actor's
+// fallback method (METHOD_FALLBACK) rather than "<unknown>", so the value
+// transfer is still surfaced (e.g. an EVM-originated value transfer to a plain
+// account actor handled by the account's fallback method).
+func resolveMethodName(actorName string, method abi.MethodNum) string {
+	if methodName := findMethodInActor(actorName, method); methodName != actors.UnknownStr {
+		return methodName
 	}
 
-	val := reflect.Indirect(reflect.ValueOf(method))
+	if isAccountActorFallback(actorName, method) {
+		return METHOD_FALLBACK
+	}
+
+	return actors.UnknownStr
+}
+
+// findMethodInActor returns the field name of the recipient actor's method set
+// whose value matches the given method number, or actors.UnknownStr if the
+// actor is unknown or the method is not part of its method set.
+func findMethodInActor(actorName string, method abi.MethodNum) string {
+	val := reflect.Indirect(reflect.ValueOf(GetMethodByActorName(actorName)))
 
 	if val.Kind() != reflect.Struct {
-		return actors.UnknownStr, nil
+		return actors.UnknownStr
 	}
 
 	for i := 0; i < val.Type().NumField(); i++ {
-		field := val.Field(i)
-		methodNum := field.Uint()
-		if methodNum == uint64(msg.Method) {
-			methodName := val.Type().Field(i).Name
-			return methodName, nil
+		if val.Field(i).Uint() == uint64(method) {
+			return val.Type().Field(i).Name
 		}
 	}
 
-	return actors.UnknownStr, nil
+	return actors.UnknownStr
 }
 
 func GetMethodByActorName(actorName string) interface{} {

--- a/rosetta/services/helpers_test.go
+++ b/rosetta/services/helpers_test.go
@@ -3,8 +3,10 @@ package services
 import (
 	"context"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
 	filTypes "github.com/filecoin-project/lotus/chain/types"
+	"github.com/zondax/rosetta-filecoin-lib/actors"
 	"reflect"
 	"testing"
 )
@@ -30,6 +32,71 @@ func TestBuildTipSetKeyHash(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BuildTipSetKeyHash() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveMethodName(t *testing.T) {
+	// invokeEVMMethod is the FRC-42 method number for "InvokeEVM"
+	// (builtin.MethodsEVM.InvokeContract). Ethereum-originated messages carry
+	// this method number regardless of the recipient actor type.
+	const invokeEVMMethod = abi.MethodNum(3844450837)
+
+	tests := []struct {
+		name      string
+		actorName string
+		method    abi.MethodNum
+		want      string
+	}{
+		{
+			name:      "EVM actor InvokeEVM resolves to InvokeContract",
+			actorName: "evm",
+			method:    invokeEVMMethod,
+			want:      "InvokeContract",
+		},
+		{
+			name:      "account actor InvokeEVM falls back to Send",
+			actorName: ACCOUNT_ACTOR_NAME,
+			method:    invokeEVMMethod,
+			want:      METHOD_FALLBACK,
+		},
+		{
+			name:      "ethaccount actor InvokeEVM falls back to Send",
+			actorName: ETHACCOUNT_ACTOR_NAME,
+			method:    invokeEVMMethod,
+			want:      METHOD_FALLBACK,
+		},
+		{
+			name:      "account actor known method resolves by name",
+			actorName: ACCOUNT_ACTOR_NAME,
+			method:    abi.MethodNum(2), // PubkeyAddress
+			want:      "PubkeyAddress",
+		},
+		{
+			name:      "account actor non-exported unknown method stays unknown",
+			actorName: ACCOUNT_ACTOR_NAME,
+			method:    abi.MethodNum(99),
+			want:      actors.UnknownStr,
+		},
+		{
+			name:      "placeholder actor InvokeEVM is not covered by fallback (documents current gap)",
+			actorName: "placeholder",
+			method:    invokeEVMMethod,
+			want:      actors.UnknownStr,
+		},
+		{
+			name:      "unknown actor stays unknown",
+			actorName: "not-a-real-actor",
+			method:    invokeEVMMethod,
+			want:      actors.UnknownStr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveMethodName(tt.actorName, tt.method); got != tt.want {
+				t.Errorf("resolveMethodName(%q, %d) = %q, want %q", tt.actorName, tt.method, got, tt.want)
 			}
 		})
 	}

--- a/rosetta/services/helpers_test.go
+++ b/rosetta/services/helpers_test.go
@@ -86,6 +86,42 @@ func TestResolveMethodName(t *testing.T) {
 			want:      actors.UnknownStr,
 		},
 		{
+			name:      "EVM actor InvokeContractDelegate resolves by name",
+			actorName: "evm",
+			method:    abi.MethodNum(6),
+			want:      "InvokeContractDelegate",
+		},
+		{
+			name:      "multisig known method resolves by name",
+			actorName: "multisig",
+			method:    abi.MethodNum(2),
+			want:      "Propose",
+		},
+		{
+			name:      "init known method resolves by name",
+			actorName: "init",
+			method:    abi.MethodNum(2),
+			want:      "Exec",
+		},
+		{
+			name:      "account exported method at threshold falls back to Send",
+			actorName: ACCOUNT_ACTOR_NAME,
+			method:    abi.MethodNum(FIRST_EXPORTED_METHOD_NUMBER),
+			want:      METHOD_FALLBACK,
+		},
+		{
+			name:      "account method just below exported threshold stays unknown",
+			actorName: ACCOUNT_ACTOR_NAME,
+			method:    abi.MethodNum(FIRST_EXPORTED_METHOD_NUMBER - 1),
+			want:      actors.UnknownStr,
+		},
+		{
+			name:      "account fallback matching is case-insensitive",
+			actorName: "Account",
+			method:    invokeEVMMethod,
+			want:      METHOD_FALLBACK,
+		},
+		{
 			name:      "unknown actor stays unknown",
 			actorName: "not-a-real-actor",
 			method:    invokeEVMMethod,
@@ -100,6 +136,36 @@ func TestResolveMethodName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetMethodNameShortcuts(t *testing.T) {
+	// These branches short-circuit before any actor/lib resolution, so they can
+	// be exercised with a nil lib.
+	t.Run("nil message returns an error", func(t *testing.T) {
+		if name, err := GetMethodName(nil, nil); err == nil {
+			t.Fatalf("expected an error for a nil message, got name %q", name)
+		}
+	})
+
+	t.Run("method 0 resolves to Send", func(t *testing.T) {
+		name, err := GetMethodName(&filTypes.MessageTrace{Method: abi.MethodNum(0)}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != METHOD_SEND {
+			t.Errorf("GetMethodName(method=0) = %q, want %q", name, METHOD_SEND)
+		}
+	})
+
+	t.Run("method 1 resolves to Constructor", func(t *testing.T) {
+		name, err := GetMethodName(&filTypes.MessageTrace{Method: abi.MethodNum(1)}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != "Constructor" {
+			t.Errorf("GetMethodName(method=1) = %q, want %q", name, "Constructor")
+		}
+	})
 }
 
 func TestValidateNetworkId(t *testing.T) {


### PR DESCRIPTION
## Problem

Messages using the exported EVM method **`InvokeEVM`** (method number `3844450837`) sent to a plain **`account`** actor were parsed as operation type `unknown` instead of a meaningful method — even when value was transferred.

Reported example tx: `bafy2bzacedyutaqjt2zw4kkldcjcj72l5qxll2dnwq3kjm5uzix3fdccetxco` (to `f03371596`, an `account` actor, ~11.53 FIL).

Note: `3844450837` is a **single** method — `FRC42("InvokeEVM")` = go-state-types `builtin.MethodsEVM.InvokeContract`. The label depends on the **recipient actor type**, not the method number.

## Root cause

The `account`/`ethaccount` fallback branch in `GetMethodName` (added in #292) was **unreachable dead code**: its guard required `GetMethodByActorName(actorName) == actors.UnknownStr`, but that function returns a *struct* for `"account"` and `"ethaccount"`, so the guard was never satisfied. The method therefore fell through to `<unknown>`.

The value itself was never lost — `block.go`'s default branch still emits debit/credit ops for `value != 0` — so this was a **labeling** bug, not a balance-reconciliation bug.

## Change

- Extract a pure, testable `resolveMethodName()` / `findMethodInActor()` seam: look the method number up in the recipient actor's **own** method set first, then fall back to `METHOD_FALLBACK` for `account`/`ethaccount` **exported** methods (`>= 1<<24`).
- `METHOD_FALLBACK` stays `"Send"` (unchanged), so these value transfers surface as ordinary **`Send`** operations — the behavior the dead branch originally intended.
- Add `TestResolveMethodName` — the end-to-end `GetMethodName`-level coverage that was missing and let this bug hide (the prior test only exercised `FindMethodNameInAllActors` in isolation).

`block.go` and `SupportedOperations` are **untouched**: `"Send"` is already handled.

**`evm` contract recipients still resolve to `InvokeContract` → `EVM_CALL`, unchanged.**

## Behavior

| Recipient actor | method `3844450837` — before | after |
|---|---|---|
| `evm` | `EVM_CALL` | `EVM_CALL` (unchanged) |
| `account` | `unknown` | **`Send`** |
| `ethaccount` | `unknown` | **`Send`** |
| `placeholder` | `unknown` | `unknown` (see below) |

## Verification

- `gofmt` clean, `go vet` clean, `golangci-lint` (new-issues vs `master`) 0 issues
- `TestResolveMethodName` (7 cases) passes; `make test` (`./rosetta/services`) passes

## Notes / possible follow-ups

- **`ethaccount` → `Send` here diverges from beryx**, which labels ethaccount `InvokeEVM` as `InvokeContract` (it remaps ethaccount→EVM table). Grouped with `account` for now.
- **`placeholder`** recipients still resolve to `unknown` (not covered by `isAccountActorFallback`); fil-parser resolves these to `InvokeContract`. Documented by a test case.
